### PR TITLE
Fixed reporter under Windows

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -16,17 +16,21 @@ var CoverageRemap = function(basePath, fileList) {
     var collector = remapIstanbul(coverage, {
       basePath: basePath,
       readFile: function(filePath) {
+        // Always use "/" slashes when comparing to servedFiles
+        var comparePath = filePath.replace(/\\/g, '/');
         var file = servedFiles.find(function(file) {
-          return file.path == filePath;
+          return file.path == comparePath;
         });
         if (!file)
           throw new Error('Unable to lookup source for ' + filePath);
         return file._preprocessedSource + (file._preprocessedSourceMap ? '\n//# sourceMappingURL=' + filePath.split(path.sep).pop() + '.map' : '');
       },
       readJSON: function(filePath) {
-        filePath = filePath.substr(0, filePath.length - 4)
+        filePath = filePath.substr(0, filePath.length - 4);
+        // Always use "/" slashes when comparing to servedFiles
+        var comparePath = filePath.replace(/\\/g, '/');
         var file = servedFiles.find(function(file) {
-          return file.path == filePath;
+          return file.path == comparePath;
         });
         if (!file)
           throw new Error('Unable to lookup source map for ' + filePath);


### PR DESCRIPTION
Fixed reporter breaking under Windows due to comparison between filepaths when one has changed "\" to "/".
